### PR TITLE
Faster / smaller sin table generator

### DIFF
--- a/cinter.asm
+++ b/cinter.asm
@@ -34,44 +34,29 @@ CinterInit:
 
 CinterMakeSinus:
                      lea        c_Sinus(a6),a0
-                     addq.l     #2,a0
-                     lea.l      CINTER_DEGREES/2*2-2(a0),a1
-
-                     moveq.l    #1,d7
-.loop:
-                     move.w     d7,d1
-                     mulu.w     d7,d1
-                     lsr.l      #8,d1
-
-                     move.w     #2373,d0
-                     mulu.w     d1,d0
-                     swap.w     d0
-                     neg.w      d0
-                     add.w      #21073,d0
-                     mulu.w     d1,d0
-                     swap.w     d0
-                     neg.w      d0
-                     add.w      #51469,d0
-                     mulu.w     d7,d0
-                     lsr.l      #8,d0
-                     lsr.l      #5,d0
-
-                     move.w     d0,(a0)+
-                     move.w     d0,-(a1)
-                     neg.w      d0
-                     move.w     d0,CINTER_DEGREES/2*2-2(a0)
-                     move.w     d0,CINTER_DEGREES/2*2(a1)
-
-                     addq.w     #1,d7
-                     cmp.w      #CINTER_DEGREES/4,d7
-                     blt.b      .loop
-
-                     move.w     #16384,d0
-                     move.w     d0,(a0)+
-                     move.w     d0,-(a1)
-                     neg.w      d0
-                     move.w     d0,CINTER_DEGREES/2*2-2(a0)
-                     move.w     d0,CINTER_DEGREES/2*2(a1)
+                     lea.l      CINTER_DEGREES/2*2(a0),a1
+                     moveq      #0,d0
+                     move.l     #$4000000,d1
+                     move.w     #CINTER_DEGREES/4-1,d7
+loop:                move.l     d1,d2
+                     asl.l      #4,d2
+                     swap       d2
+                     ext.l      d2
+                     add.l      d2,d0
+                     move.l     d0,d2
+                     asl.l      #4,d2
+                     swap       d2
+                     ext.l      d2
+                     sub.l      d2,d1
+                     add.b      #163,d3
+                     bcc        loop
+                     move.w     d2,d4
+                     neg.w      d4
+                     move.w     d2,(a0)+
+                     move.w     d4,CINTER_DEGREES/2*2-2(a0)
+                     move.w     d4,CINTER_DEGREES/2*2-2(a1)
+                     move.w     d2,-(a1)
+                     dbra.w     d7,loop
 
 ; Sample parameters:
 ; short length, replength


### PR DESCRIPTION
With apologies for my lack of expertise (this is my first published Amiga code), I think this is a faster sine generator than vanilla Cinter, whilst being shorter and just as accurate. Even though I've got rid of a load of MULs, it doesn't save that much time - but every byte and every millisecond counts for $\Bbb T \Bbb T \Bbb E$, right?

### Code review notes
* This uses an [MCF oscillator](https://ccrma.stanford.edu/~jos/pasp/Digital_Sinusoid_Generators.html).
* The oscillator rotates in more than `CINTER_DEGREES` steps, so the division factor $\epsilon=2^{-12}$ and can be done with a shift. The `d3` shenanigans does sample skipping that retimes the oscillator so the resulting wave matches `CINTER_DEGREES`.
* `d3` is not initialised, and that is deliberate. Its initial value gives a sub-sample phase difference to the output table that won't be audible. Initialising it provides an output very close to Cinter, but there's no point wasting bytes on a `moveq #46,d3` if you can't hear the difference.
