### PR TITLE
Add .gitattributes to enforce eol=lf on text/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text/** text eol=lf


### PR DESCRIPTION
This *should* mean that the INCBINed files in the text/ directory are always checked out to the local workspace with LF line endings.

Resolves https://github.com/djh0ffman/TinyTro/issues/2