### PR TITLE
Remove duplicate JMPINDEX macro from macros.asm

### DIFF
--- a/macros.asm
+++ b/macros.asm
@@ -58,15 +58,3 @@ RANDOMWORD    MACRO
               swap.w     d0
               move.l     (sp)+,d1
               ENDM
-
-
-
-** jump index
-** 1 = index
-
-JMPINDEX      MACRO
-              add.w      \1,\1
-              move.w     .\@jmplist(pc,\1.w),\1
-              jmp        .\@jmplist(pc,\1.w)
-.\@jmplist
-              ENDM


### PR DESCRIPTION
This was causing a build error on the latest version of vasm (2.0beta):

```
error 89 in line 67 of "macros.asm": macro redefinition
        included from line 38 of "tinytro.asm"
>JMPINDEX      MACRO
```

For more information, see https://eab.abime.net/showthread.php?p=1662681

Resolves https://github.com/djh0ffman/TinyTro/issues/3